### PR TITLE
Allow additional attributes to spans

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,3 +3,6 @@ import Config
 config :opentelemetry,
   tracer: :otel_tracer_default,
   processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]
+
+# Print only warnings and errors during tests
+config :logger, :console, level: :warn

--- a/lib/batch_instrumentation.ex
+++ b/lib/batch_instrumentation.ex
@@ -14,7 +14,8 @@ defmodule OpentelemetryAbsinthe.BatchInstrumentation do
   @tracer_id __MODULE__
 
   @default_config [
-    batch_span_name: "absinthe graphql batch"
+    batch_span_name: "absinthe graphql batch",
+    additional_attributes: %{}
   ]
 
   def setup(instrumentation_opts \\ []) do
@@ -46,7 +47,8 @@ defmodule OpentelemetryAbsinthe.BatchInstrumentation do
 
   def handle_batch_start(_event_name, _measurements, metadata, config) do
     batch_function_name = OpentelemetryAbsinthe.Helpers.get_batch_function_as_string(metadata.batch_fun)
-    attributes = [{:"graphql.batch.function", batch_function_name}]
+    additional_attributes = Map.new(config.additional_attributes)
+    attributes = Map.merge(%{"graphql.batch.function": batch_function_name}, additional_attributes)
 
     execution_ctx =
       OpentelemetryAbsinthe.Registry.get_absinthe_execution_span() || OpenTelemetry.Tracer.current_span_ctx()

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -20,7 +20,8 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     trace_request_query: true,
     trace_request_variables: true,
     trace_response_result: false,
-    trace_response_errors: true
+    trace_response_errors: true,
+    additional_attributes: %{}
   ]
 
   def setup(instrumentation_opts \\ []) do
@@ -54,7 +55,8 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     params = metadata |> Map.get(:options, []) |> Keyword.get(:params, %{})
 
     attributes =
-      %{}
+      config.additional_attributes
+      |> Map.new()
       |> put_if(
         config.trace_request_variables,
         :"graphql.request.variables",

--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -3,9 +3,9 @@ defmodule OpentelemetryAbsinthe do
   OpentelemetryAbsinthe is an opentelemetry instrumentation library for Absinthe
   """
 
-  def setup() do
-    OpentelemetryAbsinthe.Instrumentation.setup()
-    OpentelemetryAbsinthe.ResolveInstrumentation.setup()
-    OpentelemetryAbsinthe.BatchInstrumentation.setup()
+  def setup(opts \\ []) do
+    OpentelemetryAbsinthe.Instrumentation.setup(opts)
+    OpentelemetryAbsinthe.ResolveInstrumentation.setup(opts)
+    OpentelemetryAbsinthe.BatchInstrumentation.setup(opts)
   end
 end

--- a/lib/resolve_instrumentation.ex
+++ b/lib/resolve_instrumentation.ex
@@ -13,7 +13,8 @@ defmodule OpentelemetryAbsinthe.ResolveInstrumentation do
   @tracer_id __MODULE__
 
   @default_config [
-    resolve_span_name: "absinthe graphql resolve"
+    resolve_span_name: "absinthe graphql resolve",
+    additional_attributes: %{}
   ]
 
   def setup(instrumentation_opts \\ []) do
@@ -53,12 +54,16 @@ defmodule OpentelemetryAbsinthe.ResolveInstrumentation do
       |> Enum.filter(fn path -> not is_integer(path) end)
       |> Enum.map(fn field -> safe_string_to_atom(field) end)
 
-    attributes = %{
-      "graphql.field.name": safe_string_to_atom(metadata.resolution.definition.name),
-      "graphql.field.alias": safe_string_to_atom(metadata.resolution.definition.alias),
-      "graphql.full_field_path": full_field_path,
-      "graphql.name_field_path": name_field_path
-    }
+    additional_attributes = Map.new(config.additional_attributes)
+
+    attributes =
+      %{
+        "graphql.field.name": safe_string_to_atom(metadata.resolution.definition.name),
+        "graphql.field.alias": safe_string_to_atom(metadata.resolution.definition.alias),
+        "graphql.full_field_path": full_field_path,
+        "graphql.name_field_path": name_field_path
+      }
+      |> Map.merge(additional_attributes)
 
     execution_ctx =
       OpentelemetryAbsinthe.Registry.get_absinthe_execution_span() || OpenTelemetry.Tracer.current_span_ctx()

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
       {:absinthe, ">= 1.7.0", optional: true},
       {:jason, "~> 1.2"},
       {:opentelemetry_api, "~> 1.0"},
-      {:telemetry, "~> 1.0.0"},
+      {:telemetry, "~> 1.0"},
       {:opentelemetry_telemetry, "~> 1.0.0-beta.7"}
     ] ++ dev_deps()
   end

--- a/test/batch_instrumentation_test.exs
+++ b/test/batch_instrumentation_test.exs
@@ -43,6 +43,15 @@ defmodule OpentelemetryAbsintheTest.BatchInstrumentation do
       assert data(attributes)[:"graphql.batch.function"] == "Elixir.AbsinthePlug.Test.Schema batch_get_profile_picture"
       assert span(data, :name) == :"absinthe graphql batch Elixir.AbsinthePlug.Test.Schema batch_get_profile_picture"
     end
+
+    test "additional attributes are included in spans" do
+      additional_attributes = [env: "test"]
+      OpentelemetryAbsinthe.BatchInstrumentation.setup(additional_attributes: additional_attributes)
+      {:ok, _} = Absinthe.run(@query, Schema, variables: %{"isbn" => "A1"})
+      assert_receive {:span, span(attributes: attributes)}, 5000
+
+      assert data(attributes)[:env] == "test"
+    end
   end
 
   defp keys(attributes_record), do: attributes_record |> elem(4) |> Map.keys()

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -80,6 +80,25 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
                :"graphql.response.errors"
              ] = attributes |> keys() |> Enum.sort()
     end
+
+    test "additional attributes are included in spans" do
+      additional_attributes = [env: "test"]
+      OpentelemetryAbsinthe.Instrumentation.setup(additional_attributes: additional_attributes)
+
+      {:ok, _} = Absinthe.run(@query, Schema, analyze_complexity: true, variables: %{"isbn" => "A1"})
+      assert_receive {:span, span(attributes: attributes)}, 5000
+
+      assert [
+               :env,
+               :"graphql.operation.complexity",
+               :"graphql.operation.name",
+               :"graphql.request.query",
+               :"graphql.request.variables",
+               :"graphql.response.errors"
+             ] = attributes |> keys() |> Enum.sort()
+
+      assert elem(attributes, 4)[:env] == "test"
+    end
   end
 
   defp keys(attributes_record), do: attributes_record |> elem(4) |> Map.keys()

--- a/test/resolve_instrumentation_test.exs
+++ b/test/resolve_instrumentation_test.exs
@@ -78,6 +78,21 @@ defmodule OpentelemetryAbsintheTest.ResolveInstrumentation do
                  span(data, :name) == :"absinthe graphql resolve comments"
              end)
     end
+
+    test "additional attributes are included in spans" do
+      additional_attributes = [env: "test"]
+      OpentelemetryAbsinthe.ResolveInstrumentation.setup(additional_attributes: additional_attributes)
+      {:ok, _} = Absinthe.run(@nested_query, Schema, variables: %{"isbn" => "A1"})
+      assert_receive {:span, data1}, 5000
+      assert_receive {:span, data2}, 5000
+
+      spans = [data1, data2]
+
+      assert Enum.all?(spans, fn data ->
+               attributes = span(data, :attributes)
+               data(attributes)[:env] == "test"
+             end)
+    end
   end
 
   defp data(attributes_record), do: attributes_record |> elem(4)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -40,7 +40,7 @@ defmodule AbsinthePlug.Test.Schema do
     field(:author, :author)
 
     field(:comments, list_of(:string)) do
-      resolve(fn _, args, _ ->
+      resolve(fn _, _, _ ->
         {:ok, ["comment1", "comment2"]}
       end)
     end


### PR DESCRIPTION
This PR adds several little things:
1. Allow additional attributes in spans, this could be useful to add from which environment a span comes from for example
2. Relax telemetry version so higher versions can be installed (I don't know if this could cause some problems)
3. Configure console logger level to `:warn`, the test don't capture logs and I think it looks cleaner this way